### PR TITLE
Custom grid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.5)
 project(licpy)
 
 add_compile_options(

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,6 +60,8 @@ To understand how the LicPy library is to be used, one can take a look at the :p
 
 The :py:func:`runlic` function does most of the heavy-lifting. It takes as arguments the x- and y-component of the velocity at each pixel position, and the lenght L of the stream along with to convolute, and the result is returned as a grey-scale texture, which can then be saved into an image file using the :py:func:`grey_save` function.
 
+`runlic` can generate a random background grid to distort with the LIC algorithm, or the background grid can be specified with the `tex=` kwarg.
+
 References
 ------------
 

--- a/licpy/lic.py
+++ b/licpy/lic.py
@@ -1,7 +1,9 @@
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior() 
 
-from licpy.pixelize import pixelize
+
+from .pixelize import pixelize
 
 INF = 1e10
 
@@ -297,11 +299,14 @@ def runlic_resample(N, M, x, y, vx, vy, L, magnitude=True):
     return runlic(vx, vy, L, magnitude)
 
 
-def runlic(vx, vy, L, magnitude=True):
+def runlic(vx, vy, L, tex=None, magnitude=True):
     assert vx.shape == vy.shape
     N, M = vx.shape
     np.random.seed(13)
-    tex = np.random.rand(N, M)
+    if tex is None:
+        tex = np.random.rand(N, M)
+    else:
+        assert tex.shape == vx.shape
 
     tex_ = tf.placeholder(tf.float64, [N, M])
     vx_ = tf.placeholder(tf.float64, [N, M])

--- a/licpy/pixelize.py
+++ b/licpy/pixelize.py
@@ -1,4 +1,4 @@
-from licpy.resample import resample_s, resample_endpoints_s
+from .resample import resample_s, resample_endpoints_s
 
 
 def interpol(v, i, j, sx, sy):


### PR DESCRIPTION
A few updates

- allow custom grid to be distorted, so you can feed in data from a simulation or observation and overlay the LIC distortion on top (as is used for polarisation plots in astrophysics observations, and for velocity fields in astrophysics simulations)

- modifying imports for consistency

- modified import for tensorflow to support older logic used in code

- allow earlier versions of CMake (version 4 previously required is not in standard apt-get management for some older versions of Ubuntu, but it compiles fine with 3.5)

(Note: this is my first pull request, hopefully I'm doing this right!)